### PR TITLE
Upgrade for latest sqlite-utils

### DIFF
--- a/feed_to_sqlite/ingest.py
+++ b/feed_to_sqlite/ingest.py
@@ -36,7 +36,7 @@ def ingest_feed(db, *, url=None, feed_content="", table_name=None, normalize=Non
         return
 
     feeds = get_feeds_table(db, FEEDS_TABLE)
-    feeds.upsert(extract_feed_fields(feeds, f.feed))
+    feeds.upsert(extract_feed_fields(feeds, f.feed), pk="id")
 
     entries = get_entries_table(db, table_name, f.feed)
 
@@ -81,7 +81,7 @@ def get_feeds_table(db, table_name=FEEDS_TABLE):
     """
     table = db[table_name]
 
-    if not table.exists:
+    if not table.exists():
         table.create(
             {
                 "id": str,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         [console_scripts]
         feed-to-sqlite=feed_to_sqlite.cli:cli
     """,
-    install_requires=["sqlite-utils", "requests", "feedparser", "awesome-slugify",],
+    install_requires=["sqlite-utils>=2.22", "requests", "feedparser", "awesome-slugify",],
     extras_require={"test": ["pytest"]},
     tests_require=["feed-to-sqlite[test]"],
     url="https://github.com/eyeseast/feed-to-sqlite",


### PR DESCRIPTION
`sqlite-utils` had a couple of changes in the past 11 months which caused this script to break. In particular:

- `table.exists` is now `table.exists()`
- The `.upsert()` method now requires the `pk=` argument.